### PR TITLE
Re-introduce dependencyInsightEnhanced

### DIFF
--- a/src/main/kotlin/com/netflix/nebula/dependencybase/DependencyBasePlugin.kt
+++ b/src/main/kotlin/com/netflix/nebula/dependencybase/DependencyBasePlugin.kt
@@ -53,8 +53,15 @@ class DependencyBasePlugin: Plugin<Project> {
     }
 
     private fun setupDependencyInsightEnhanced(project: Project) {
-        insightTask = project.tasks.replace("dependencyInsight", NebulaDependencyInsightReportTask::class.java)
+        insightTask = project.tasks.create("dependencyInsightEnhanced", NebulaDependencyInsightReportTask::class.java)
         insightTask.reasonLookup = dependencyManagement
+        project.afterEvaluate {
+            it.tasks.findByName("dependencyInsight").apply {
+                if (this == null) return@afterEvaluate
+                dependsOn(insightTask)
+                enabled = false
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This is to avoid the deprecation warning message in Gradle 4.8 for creating a new task with the same name.

* Create our task as dependencyInsightEnhanced
* After a project is evaluated, find its dependencyInsight task - necessary for multiprojects
* Add a dependency on dependencyInsightEnhanced from dependencyInsight
* Disable dependencyInsight so it is SKIPPED, but still runs our dependent task
* Have our task look up the options given to the original dependencyInsight task - multiple classes with the same options are apparently not set. The original always had a value, but ours was null.

Users will still be able to see enhanced results from running dependencyInsight:

```
:dependencyInsightEnhanced (Thread[Task worker for ':',5,main]) started.

> Task :dependencyInsightEnhanced
Caching disabled for task ':dependencyInsightEnhanced': Caching has not been enabled for the task
Task ':dependencyInsightEnhanced' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
test.nebula:foo:1.0.0 (recommend 1.0.0 via NebulaTest)

test.nebula:foo -> 1.0.0
\--- compileClasspath
:dependencyInsightEnhanced (Thread[Task worker for ':',5,main]) completed. Took 0.181 secs.
:dependencyInsight (Thread[Task worker for ':',5,main]) started.

> Task :dependencyInsight SKIPPED
```